### PR TITLE
feat: authentication navbar, profile refactor and config setup

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -1,7 +1,7 @@
 from flask import render_template, request, redirect, url_for, jsonify
 from app import app, db
 from sqlalchemy import desc, func
-from flask_login import login_required, current_user, logout_user
+from flask_login import login_user, login_required, current_user, logout_user
 from app.models import (
     Recipe,
     Comment,
@@ -112,25 +112,13 @@ def profile():
     # TODO: replace with --> test_user = current_user
     test_user = User.query.filter_by(email='emma@example.com').first()
 
+    if not current_user.is_authenticated:
+        login_user(test_user)
+
     # Gather all recipes owned by user, liked by user and favourited by users via relationships
     user_recipes = Recipe.query.filter_by(user_id=test_user.id).all()
     liked_recipes = [like.recipe for like in test_user.likes]
     fav_recipes = [fav.recipe for fav in test_user.favourites]
-
-    # Helper function to convert DB recipe to frontend-friendly card format
-    def format_recipe_card(recipe):
-        is_liked = recipe in liked_recipes
-        return {
-            'id': recipe.id,
-            'title': recipe.title,
-            'category': recipe.category.value,
-            'image_url': recipe.image_file or url_for('static', filename='images/default.png'),
-            'rating': 0,
-            'likes': len(recipe.likes),
-            'duration': f"{recipe.cook_time} mins" if recipe.cook_time else "N/A",
-            'difficulty': recipe.difficulty.value if recipe.difficulty else "N/A",
-            'is_liked': is_liked,
-        }
 
     user = {
         'name': test_user.username,
@@ -140,11 +128,14 @@ def profile():
         'recipes_count': len(user_recipes),
         'likes_count': len(liked_recipes),
         'favourites_count': len(fav_recipes),
-        'recipes': [format_recipe_card(r) for r in user_recipes],
-        'likes': [format_recipe_card(r) for r in liked_recipes],
-        'favourites': [format_recipe_card(r) for r in fav_recipes],
+        'recipes': user_recipes,
+        'likes': liked_recipes,
+        'favourites': fav_recipes,
     }
-    return render_template('profile.html', user=user)
+
+    liked_recipe_ids = [like.recipe_id for like in test_user.likes]
+
+    return render_template('profile.html', user=user, liked_recipe_ids=liked_recipe_ids)
 
 @app.route('/profile/update', methods=['POST'])
 # TODO: uncomment @login_required and replace test_user with current_user when auth is complete
@@ -213,7 +204,7 @@ def post():
     return render_template('post.html')
 
 @app.route('/recipe/<int:id>', methods=['GET', 'POST'])
-def recipe_detail(id):
+def recipe(id):
 
     recipe = Recipe.query.get_or_404(id)
 
@@ -235,7 +226,7 @@ def recipe_detail(id):
             db.session.add(new_comment)
             db.session.commit()
 
-        return redirect(url_for('recipe_detail', id=recipe.id))
+        return redirect(url_for('recipe', id=recipe.id))
 
     related_recipes = Recipe.query.filter(
         Recipe.id != recipe.id
@@ -248,7 +239,7 @@ def recipe_detail(id):
     )
 
 @app.route('/recipe/<int:id>/like', methods=['POST'])
-def toggle_like(id):
+def like_recipe(id):
     # Handles like button interactions by adding/removing a like record
     # and synchronising frontend state with updated like count
 
@@ -287,7 +278,7 @@ def edit_recipe(id):
 
         db.session.commit()
 
-        return redirect(url_for('recipe_detail', id=recipe.id))
+        return redirect(url_for('recipe', id=recipe.id))
 
     return render_template('edit_recipe.html', recipe=recipe)
 

--- a/app/routes.py
+++ b/app/routes.py
@@ -201,6 +201,12 @@ def signup():
 def login():
     return render_template('login.html')
 
+@app.route('/logout')
+@login_required
+def logout():
+    logout_user()
+    return redirect(url_for('home'))
+
 
 @app.route('/post')
 def post():

--- a/app/static/js/profile_script.js
+++ b/app/static/js/profile_script.js
@@ -141,12 +141,14 @@ document.querySelectorAll('.heart-btn').forEach(btn => {
         e.preventDefault()
         e.stopPropagation()
 
-        // Get recipe ID from parent card (data-recipe-id attribute)
-        const card = btn.closest('[data-recipe-id]')
-        const recipeId = card.dataset.recipeId
+        // Get the form's action URL which has the recipe id
+        const form = btn.closest('form')
+        const url = form.action
+        const card = btn.closest('[data-recipe-id]') || btn.closest('article')
+        const recipeId = url.split('/')[2] // extracts id from /recipe/id/like
 
         // Send POST request to toggle like/unlike in backend
-        const res = await fetch(`/recipe/${recipeId}/like`, { method: 'POST' })
+        const res = await fetch(url, { method: 'POST' })
         const data = await res.json()
         
         // Icon inside heart button
@@ -162,7 +164,7 @@ document.querySelectorAll('.heart-btn').forEach(btn => {
             const clonedCard = card.closest('.col-12').cloneNode(true)
             likesTab.appendChild(clonedCard)
 
-            // INcrement likes counter in profile stats
+            // Increment likes counter in profile stats
             const likesCount = document.querySelector('.stat:nth-child(3) .stat-number')
             likesCount.textContent = parseInt(likesCount.textContent) + 1
 

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -20,7 +20,7 @@
 <body>
     <nav class="topnav">
         <div class="nav-left">
-            <span class="logo-text">CozyCravings</span>
+            <a href="{{ url_for('home') }}" class = "logo-text" >CozyCravings</a>
         </div>
 
         <div class="nav-right">
@@ -31,11 +31,12 @@
                 <a href="{{ url_for('profile') }}" class="nav-circle">
                     <span class="material-icons">account_circle</span>
                 </a>
+                <a href="{{ url_for('logout') }}" class="signup-btn">Logout</a>
             {% else %}
                 <a href="{{ url_for('login') }}" class="nav-circle">
                     <span class="material-icons">account_circle</span>
                 </a>
-                <a href="{{ url_for('signup') }}" class="signup-btn">Signup</a>
+                <a href="{{ url_for('signup') }}" class="signup-btn">Sign up</a>
             {% endif %}
         </div>
     </nav>

--- a/app/templates/profile.html
+++ b/app/templates/profile.html
@@ -13,69 +13,6 @@
 {% block content %}
 
 
-{% macro recipe_cards(recipes, is_owner=False) %}
-<div class="container">
-    <div class="row g-4">
-        {% for recipe in recipes %}
-        <div class="col-12 col-md-6 col-lg-4">
-            <a href="{{ url_for('recipe_detail', id=recipe.id) }}" class="recipe-link">
-                <div class="recipe-card" data-recipe-id="{{ recipe.id }}">
-                    <figure style="position: relative;">
-                        <img src="{{ recipe.image_url }}" alt="{{ recipe.title }}">
-                        
-                        {# Heart button: only shown on other people's recipes, not your own #}
-                        {% if not is_owner %}
-                        <button class="heart-btn {% if recipe.is_liked %}liked{% endif %}">
-                            <span class="material-icons">
-                                {% if recipe.is_liked %}favorite{% else %}favorite_border{% endif %}
-                            </span>
-                        </button>
-                        {% endif %}
-                        
-                        {# Edit button: only shown on the owner's own recipes #}
-                        {% if is_owner %}
-                        <button class="edit-btn"
-                            onclick="event.stopPropagation(); window.location.href='{{ url_for('edit_recipe', id=recipe.id) }}';">
-                            <span class="material-icons">edit</span>
-                        </button>
-                        {% endif %}
-                    </figure>
-                    <div class="recipe-card-content">
-                        <div class="card-meta">
-                            <div class="recipe-tags">
-                                <span class="recipe-tag">{{ recipe.category }}</span>
-                            </div>
-
-                            {# Recipe stats: rating, likes, duration, difficulty #}
-                            <ul class="recipe-stats">
-                                <li><span class="material-icons icon-sm" >star</span> {{ recipe.rating }}</li>
-                                <li><span class="material-icons icon-sm" >favorite</span> {{ recipe.likes }}</li>
-                                <li><span class="material-icons icon-sm" >schedule</span> {{ recipe.duration }}</li>
-                                <li>
-                                    <span class="difficulty {{ recipe.difficulty | lower }}">
-                                        <span class="material-icons icon-sm" >local_fire_department</span>
-                                        {{ recipe.difficulty }}
-                                    </span>
-                                </li>
-                            </ul>
-                        </div>
-                        <h1>{{ recipe.title }}</h1>
-                        <div class="recipe-footer">
-                            <div class="user-info">
-                                <span class="material-icons icon-md" >account_circle</span>
-                                <span class="username">{{ user.name }}</span>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-            </a>
-        </div>
-        {% endfor %}
-    </div>
-</div>
-{% endmacro %}
-
-
 <div class="profile-container">
     
     {# Profile Header: avatar, name, bio, and stats #}
@@ -179,25 +116,32 @@
         </div>
     
     {# Profile Tabs: switch between My Recipes, Favourites, and Likes #}
+    
+    {% set tabs = [
+        ('my-recipes', user.recipes, True),
+        ('favourites', user.favourites, False),
+        ('likes', user.likes, False)
+    ] %}
+
     <div class="profile-tabs">
         <button class="profile-tab active" data-tab="my-recipes">My Recipes</button>
         <button class="profile-tab" data-tab="favourites">Favourites</button>
         <button class="profile-tab" data-tab="likes">Likes</button>
     </div>
 
-    {# Tab content: each section uses the recipe_cards macro #}
-    <div class="profile-tab-content active" id="my-recipes">
-        {# is_owner=True hides heart button and shows edit button #}
-        {{ recipe_cards(user.recipes, is_owner=user.is_owner) }}
+    {% for tab_id, recipes, is_active in tabs %}
+    <div class="profile-tab-content {% if is_active %}active{% endif %}" id="{{ tab_id }}">
+        <div class="container">
+            <div class="row g-4">
+                {% for recipe in recipes %}
+                <div class="col-12 col-md-6 col-lg-4">
+                    {% include "recipe_card.html" %}
+                </div>
+                {% endfor %}
+            </div>
+        </div>
     </div>
-
-    <div class="profile-tab-content" id="favourites">
-        {{ recipe_cards(user.favourites) }}
-    </div>
-
-    <div class="profile-tab-content" id="likes">
-        {{ recipe_cards(user.likes) }}
-    </div>
+    {% endfor %}
     
     {# Bye popup: shown briefly after account deletion before redirecting home #}
     <div class="bye-popup-overlay" id="byePopupOverlay"></div>

--- a/app/templates/recipe.html
+++ b/app/templates/recipe.html
@@ -322,7 +322,7 @@ block content %}
           {% if related_recipes %} {% for related in related_recipes %}
 
           <a
-            href="{{ url_for('recipe_detail', id=related.id) }}"
+            href="{{ url_for('recipe', id=related.id) }}"
             class="related-recipe text-decoration-none"
           >
             <!-- IMAGE -->

--- a/config.py
+++ b/config.py
@@ -1,5 +1,7 @@
 import os
+from dotenv import load_dotenv
 
+load_dotenv()
 basedir = os.path.abspath(os.path.dirname(__file__))
 
 class Config:

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ Flask-Login==0.6.3
 Flask-Migrate==4.1.0
 Flask-SQLAlchemy==3.1.1
 Flask-WTF==1.2.2
-greenlet==3.2.5
+greenlet==3.2.4
 idna==3.13
 importlib_metadata==8.7.1
 itsdangerous==2.2.0
@@ -22,6 +22,7 @@ MarkupSafe==3.0.3
 mdurl==0.1.2
 ordered-set==4.1.0
 packaging==24.2
+python-dotenv==1.2.2
 Pygments==2.20.0
 rich==13.9.4
 SQLAlchemy==2.0.49


### PR DESCRIPTION
Navbar
- Added logout button for authenticated users
- Logo now redirects to homepage

Profile
- Refactored profile page to use shared recipe_card.html instead of a custom macro
- Updated profile route to pass real Recipe objects to the template

Config
- Added python-dotenv support for secret key via .env file
- Please create a .env file with SECRET_KEY=your_generated_key (see group chat for instructions)

Note
Visiting /profile and clicking home shows what the page looks like when signed in. This is temporary until login/signup is merged, test user (emma_doe) is hardcoded for now.