### PR TITLE
Refactor recipes page into unified browsing and search experience

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -102,8 +102,51 @@ def home():
 
 @app.route("/recipes")
 def recipes():
-    return render_template("browse_recipes.html")
 
+    query = request.args.get('q', '').strip()
+    difficulty = request.args.get('difficulty', '')
+    category = request.args.get('category', '')
+    sort = request.args.get('sort', '')
+
+    results_query = Recipe.query
+
+    if query:
+        results_query = results_query.filter(
+            or_(
+                Recipe.title.ilike(f'%{query}%'),
+                Recipe.description.ilike(f'%{query}%'),
+                Recipe.ingredients.ilike(f'%{query}%'),
+                Recipe.category.cast(db.String).ilike(f'%{query}%')
+            )
+        )
+
+    if difficulty:
+        results_query = results_query.filter(
+            Recipe.difficulty == DifficultyEnum[difficulty]
+        )
+
+    if category:
+        results_query = results_query.filter(
+            Recipe.category == CategoryEnum[category]
+        )
+
+    if sort == 'alphabetical':
+        results_query = results_query.order_by(
+            Recipe.title.asc()
+        )
+
+    elif sort == 'newest':
+        results_query = results_query.order_by(
+            Recipe.created_at.desc()
+        )
+
+    results = results_query.all()
+
+    return render_template(
+        'search_results.html',
+        query=query,
+        results=results
+    )
 
 @app.route("/privacy_policy")
 def privacy():
@@ -389,55 +432,6 @@ def edit_recipe(id):
 
     return render_template('edit_recipe.html', recipe=recipe)
 
-@app.route('/search')
-def search_recipes():
-
-    query = request.args.get('q', '').strip()
-    difficulty = request.args.get('difficulty', '')
-    category = request.args.get('category', '')
-    sort = request.args.get('sort', '')
-
-    results_query = Recipe.query
-
-    
-    if query:
-
-        results_query = results_query.filter(
-            or_(
-                Recipe.title.ilike(f'%{query}%'),
-                Recipe.description.ilike(f'%{query}%'),
-                Recipe.ingredients.ilike(f'%{query}%'),
-                Recipe.category.cast(db.String).ilike(f'%{query}%')
-            )
-        )
-    if difficulty:
-        results_query = results_query.filter(
-            Recipe.difficulty == DifficultyEnum[difficulty]
-        )
-
-    if category:
-        results_query = results_query.filter(
-            Recipe.category == CategoryEnum[category]
-        )
-
-    if sort == 'alphabetical':
-        results_query = results_query.order_by(
-            Recipe.title.asc()
-        )
-
-    elif sort == 'newest':
-        results_query = results_query.order_by(
-            Recipe.created_at.desc()
-        )
-
-    results = results_query.all()
-
-    return render_template(
-        'search_results.html',
-        query=query,
-        results=results
-    )
-# Vanessa's route added by Nabeel
 
 @app.route('/api/recipes')
 def api_recipes():

--- a/app/static/css/search_results.css
+++ b/app/static/css/search_results.css
@@ -24,3 +24,18 @@
 .search-results-grid .col-12 {
     margin-bottom: 1rem;
 }
+
+.recipes-search-hero {
+    background-color: #e9dfcf;
+    padding: 3rem 2rem;
+    border-radius: 24px;
+    margin: 2rem 0 3rem 0;
+    display: flex;
+    justify-content: center;
+}
+
+.recipes-search-hero .search-container {
+    background: transparent;
+    width: 100%;
+    max-width: 700px;
+}

--- a/app/static/css/search_results.css
+++ b/app/static/css/search_results.css
@@ -1,0 +1,26 @@
+.search-results-grid .recipe-card {
+    width: 100%;
+    max-width: 100%;
+    border-radius: 20px;
+}
+
+.search-results-grid .recipe-link {
+    display: block;
+    width: 100%;
+}
+
+.search-results-grid .recipe-meta {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+    align-items: center;
+}
+
+.search-results-grid .recipe-title {
+    font-size: 1.6rem;
+    line-height: 1.3;
+}
+
+.search-results-grid .col-12 {
+    margin-bottom: 1rem;
+}

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -1,88 +1,135 @@
-{# 
-    Main layout template using Jinja2 inheritance.
-    Contains the global navigation bar and the floating post button and a footer bar.
-    NOTE: Any elements intended to appear on EVERY page should be added here.
-#}
+{# Main layout template using Jinja2 inheritance. Contains the global navigation
+bar and the floating post button and a footer bar. NOTE: Any elements intended
+to appear on EVERY page should be added here. #}
 
-
-<!DOCTYPE html>
+<!doctype html>
 <html>
-<head>
+  <head>
     <title>CozyCravings</title>
-    <meta name="viewport" content="width=device-width, initial-scale=1">
-    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
-    <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css">
-    <link rel="stylesheet" href="{{ url_for('static', filename='css/style.css') }}">
-    <link rel="stylesheet" href="{{ url_for('static', filename='css/profile.css') }}">
-    <link rel="stylesheet" href="{{ url_for('static', filename='css/add_recipe.css') }}">
-</head>
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <link
+      href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css"
+      rel="stylesheet"
+    />
+    <link
+      href="https://fonts.googleapis.com/icon?family=Material+Icons"
+      rel="stylesheet"
+    />
+    <link
+      rel="stylesheet"
+      href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css"
+    />
+    <link
+      rel="stylesheet"
+      href="{{ url_for('static', filename='css/style.css') }}"
+    />
+    <link
+      rel="stylesheet"
+      href="{{ url_for('static', filename='css/profile.css') }}"
+    />
+    <link
+      rel="stylesheet"
+      href="{{ url_for('static', filename='css/add_recipe.css') }}"
+    />
+    {% block extra_css %}{% endblock %}
+  </head>
 
-<body>
+  <body>
     <nav class="topnav">
-        <div class="nav-left">
-            <a href="{{ url_for('home') }}" class = "logo-text" >CozyCravings</a>
-        </div>
+      <div class="nav-left">
+        <a href="{{ url_for('home') }}" class="logo-text">CozyCravings</a>
+      </div>
 
-        <div class="nav-right">
-            <a href="{{ url_for('home') }}" class = "nav-text" >Home</a>
-            <a href="{{ url_for('recipes') }}" class = "nav-text"> All Recipes</a>
-            <a href="{{ url_for('add_recipe') }}" class="nav-text create-link"> + Create Recipe</a>
-            
-            {% if current_user and current_user.is_authenticated %}
-                <a href="{{ url_for('profile') }}" class="nav-circle">
-                    <span class="material-icons">account_circle</span>
-                </a>
-                <a href="{{ url_for('logout') }}" class="signup-btn">Logout</a>
-            {% else %}
-                <a href="{{ url_for('login') }}" class="nav-circle">
-                    <span class="material-icons">account_circle</span>
-                </a>
-                <a href="{{ url_for('signup') }}" class="signup-btn">Sign up</a>
-            {% endif %}
-        </div>
+      <div class="nav-right">
+        <a href="{{ url_for('home') }}" class="nav-text">Home</a>
+        <a href="{{ url_for('recipes') }}" class="nav-text"> All Recipes</a>
+        <a href="{{ url_for('add_recipe') }}" class="nav-text create-link">
+          + Create Recipe</a
+        >
+
+        {% if current_user and current_user.is_authenticated %}
+        <a href="{{ url_for('profile') }}" class="nav-circle">
+          <span class="material-icons">account_circle</span>
+        </a>
+        <a href="{{ url_for('logout') }}" class="signup-btn">Logout</a>
+        {% else %}
+        <a href="{{ url_for('login') }}" class="nav-circle">
+          <span class="material-icons">account_circle</span>
+        </a>
+        <a href="{{ url_for('signup') }}" class="signup-btn">Sign up</a>
+        {% endif %}
+      </div>
     </nav>
 
-    <main class="page-content">
-        {% block content %}{% endblock %}
-    </main>
+    <main class="page-content">{% block content %}{% endblock %}</main>
     {% if current_user and current_user.is_authenticated %}
-        <a href="{{ url_for('post') }}" class="floating-post-btn">
-            <span class="material-icons">add</span>
-        </a>
+    <a href="{{ url_for('post') }}" class="floating-post-btn">
+      <span class="material-icons">add</span>
+    </a>
     {% endif %}
 
-
     <footer class="site-footer">
-        <div class="footer-container">
-            <div class="footer-brand">
-                <img src="{{ url_for('static', filename='images/logo.png') }}" alt="CozyCravings Logo">
-            </div>
-
-            <div class="footer-socials">
-                    {# SECURITY EDGE CASE: add rel="noopener noreferrer" for all external links #}
-                    <a href="https://www.instagram.com/" target ="_blank" rel="noopener noreferrer" aria-label="Instagram"><i class="fa-brands fa-instagram"></i></a>
-                    <a href="https://www.tiktok.com/" target ="_blank" rel="noopener noreferrer" aria-label="TikTok"><i class="fa-brands fa-tiktok"></i></a>
-                    <a href="https://x.com/" target ="_blank" rel="noopener noreferrer" aria-label="Twitter"><i class="fa-brands fa-x-twitter"></i></a>
-                    <a href="https://www.facebook.com/" target ="_blank" rel="noopener noreferrer" aria-label="Facebook"><i class="fa-brands fa-facebook"></i></a>
-            </div>
+      <div class="footer-container">
+        <div class="footer-brand">
+          <img
+            src="{{ url_for('static', filename='images/logo.png') }}"
+            alt="CozyCravings Logo"
+          />
         </div>
 
-        <hr class="footer-divider">
-
-        <div class="footer-bottom">
-            <p>&copy; 2026 CozyCravings.com</p>
-            <nav class="footer-legal">
-                <a href="{{ url_for('terms') }}">Terms & Conditions</a>
-                <a href="{{ url_for('privacy') }}">Privacy Policy</a>
-            </nav>
+        <div class="footer-socials">
+          {# SECURITY EDGE CASE: add rel="noopener noreferrer" for all external
+          links #}
+          <a
+            href="https://www.instagram.com/"
+            target="_blank"
+            rel="noopener noreferrer"
+            aria-label="Instagram"
+            ><i class="fa-brands fa-instagram"></i
+          ></a>
+          <a
+            href="https://www.tiktok.com/"
+            target="_blank"
+            rel="noopener noreferrer"
+            aria-label="TikTok"
+            ><i class="fa-brands fa-tiktok"></i
+          ></a>
+          <a
+            href="https://x.com/"
+            target="_blank"
+            rel="noopener noreferrer"
+            aria-label="Twitter"
+            ><i class="fa-brands fa-x-twitter"></i
+          ></a>
+          <a
+            href="https://www.facebook.com/"
+            target="_blank"
+            rel="noopener noreferrer"
+            aria-label="Facebook"
+            ><i class="fa-brands fa-facebook"></i
+          ></a>
         </div>
+      </div>
+
+      <hr class="footer-divider" />
+
+      <div class="footer-bottom">
+        <p>&copy; 2026 CozyCravings.com</p>
+        <nav class="footer-legal">
+          <a href="{{ url_for('terms') }}">Terms & Conditions</a>
+          <a href="{{ url_for('privacy') }}">Privacy Policy</a>
+        </nav>
+      </div>
     </footer>
 
     {# Edge case: defer prevents DOM race conditions #}
-    <script defer src="{{ url_for('static', filename='js/recipe_card_script.js') }}"></script>
-    <script defer src="{{ url_for('static', filename='js/navbar_script.js') }}"></script>
-
-</body> 
-
-</html> 
+    <script
+      defer
+      src="{{ url_for('static', filename='js/recipe_card_script.js') }}"
+    ></script>
+    <script
+      defer
+      src="{{ url_for('static', filename='js/navbar_script.js') }}"
+    ></script>
+  </body>
+</html>

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -4,75 +4,35 @@ hero and a section showcasing variety of recipes. #} {% extends "base.html" %}
 {% block content %}
 
 <div class="home-container">
-    <header class="welcome-hero">
-        {% if current_user and current_user.is_authenticated %}
-            {% if current_user.recipes|length == 0 and current_user.likes|length == 0 %}
-                <h1>Welcome, {{ current_user.username }}!</h1>
-            {% else %}
-                <h1>Welcome back, {{ current_user.username }}!</h1>
-            {% endif %}
-        {% else %}
-            <h1>Welcome to CozyCravings</h1>
-        {% endif %}
+  <header class="welcome-hero">
+    {% if current_user and current_user.is_authenticated %} {% if
+    current_user.recipes|length == 0 and current_user.likes|length == 0 %}
+    <h1>Welcome, {{ current_user.username }}!</h1>
+    {% else %}
+    <h1>Welcome back, {{ current_user.username }}!</h1>
+    {% endif %} {% else %}
+    <h1>Welcome to CozyCravings</h1>
+    {% endif %}
 
-<form
-  action="{{ url_for('recipes') }}"
-  method="GET"
-  class="search-container"
->
+    <form
+      action="{{ url_for('recipes') }}"
+      method="GET"
+      class="search-container"
+    >
+      <div class="search-main-row">
+        <input
+          class="search-field"
+          type="text"
+          name="q"
+          placeholder="What are your cravings for today?"
+          value="{{ request.args.get('q', '') }}"
+          required
+        />
 
-  <div class="search-main-row">
-    <input
-      class="search-field"
-      type="text"
-      name="q"
-      placeholder="What are your cravings for today?"
-      value="{{ request.args.get('q', '') }}"
-      required
-    />
-
-    <button type="submit">Search</button>
-  </div>
-
-  <div class="search-filter-row">
-
-    <select class="search-field" name="difficulty">
-      <option value="">All Difficulties</option>
-      <option value="EASY">Easy</option>
-      <option value="MEDIUM">Medium</option>
-      <option value="HARD"
-      {% if request.args.get('difficulty') == 'HARD' %}selected{% endif %}>
-      Hard
-      </option>
-    </select>
-
-    <select class="search-field" name="category">
-      <option value="">All Categories</option>
-      <option value="BREAKFAST">Breakfast</option>
-      <option value="BRUNCH">Brunch</option>
-      <option value="LUNCH">Lunch</option>
-      <option value="DINNER">Dinner</option>
-      <option value="SNACK">Snack</option>
-      <option value="DRINK">Drink</option>
-      <option value="DESSERT"
-      {% if request.args.get('category') == 'DESSERT' %}selected{% endif %}>
-      Dessert
-      </option>
-    </select>
-
-    <select class="search-field" name="sort">
-      <option value="">Sort By</option>
-      <option value="alphabetical">Alphabetical</option>
-      <option value="newest"
-      {% if request.args.get('sort') == 'newest' %}selected{% endif %}>
-      Newest
-      </option>
-    </select>
-
-  </div>
-
-</form>
-</header>
+        <button type="submit">Search</button>
+      </div>
+    </form>
+  </header>
 
   {% if error %}
   <div class="alert alert-warning text-center py-4">{{ error }}</div>
@@ -123,7 +83,5 @@ hero and a section showcasing variety of recipes. #} {% extends "base.html" %}
     </div>
   </section>
   {% endif %} {% endfor %} {% endif %}
-
-  
 </div>
 {% endblock %}

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -16,7 +16,7 @@ hero and a section showcasing variety of recipes. #} {% extends "base.html" %}
         {% endif %}
 
 <form
-  action="{{ url_for('search_recipes') }}"
+  action="{{ url_for('recipes') }}"
   method="GET"
   class="search-container"
 >

--- a/app/templates/search_results.html
+++ b/app/templates/search_results.html
@@ -1,16 +1,23 @@
-{% extends "base.html" %} {% block content %}
+{% extends "base.html" %} {% block extra_css %}
+<link
+  rel="stylesheet"
+  href="{{ url_for('static', filename='css/search_results.css') }}"
+/>
+{% endblock %} {% block content %}
 
 <div class="container py-5">
+  {% if query %}
   <h1 class="mb-4">Search Results for "{{ query }}"</h1>
-
   <p class="text-muted mb-4">{{ results|length }} recipe(s) found</p>
+  {% else %}
+  <h1 class="mb-4">Browse All Recipes</h1>
+  <p class="text-muted mb-4">{{ results|length }} recipe(s) available</p>
+  {% endif %} {% if results %}
 
-  {% if results %}
-
-  <div class="row g-4">
+  <div class="row g-4 search-results-grid">
     {% for recipe in results %}
 
-    <div class="col-12 col-md-6 col-lg-4">{% include "recipe_card.html" %}</div>
+    <div class="col-12 col-md-6">{% include "recipe_card.html" %}</div>
 
     {% endfor %}
   </div>

--- a/app/templates/search_results.html
+++ b/app/templates/search_results.html
@@ -1,9 +1,11 @@
-{% extends "base.html" %} {% block extra_css %}
-<link
-  rel="stylesheet"
-  href="{{ url_for('static', filename='css/search_results.css') }}"
-/>
-{% endblock %} {% block content %}
+{% extends "base.html" %} 
+
+{% block extra_css %}
+<link rel="stylesheet" href="{{ url_for('static', filename='css/search.css') }}">
+<link rel="stylesheet" href="{{ url_for('static', filename='css/search_results.css') }}">
+{% endblock %}
+
+{% block content %}
 
 <div class="container py-5">
   {% if query %}
@@ -12,7 +14,80 @@
   {% else %}
   <h1 class="mb-4">Browse All Recipes</h1>
   <p class="text-muted mb-4">{{ results|length }} recipe(s) available</p>
-  {% endif %} {% if results %}
+  {% endif %}
+<div class="recipes-search-hero">
+  <form
+  action="{{ url_for('recipes') }}"
+  method="GET"
+  class="search-container mb-5"
+>
+
+  <div class="search-main-row">
+    <input
+      class="search-field"
+      type="text"
+      name="q"
+      placeholder="Search recipes..."
+      value="{{ request.args.get('q', '') }}"
+    />
+
+    <button type="submit">Search</button>
+  </div>
+
+  <div class="search-filter-row">
+
+    <select class="search-field" name="difficulty">
+      <option value="">All Difficulties</option>
+      <option value="EASY"
+      {% if request.args.get('difficulty') == 'EASY' %}selected{% endif %}>
+      Easy
+      </option>
+
+      <option value="MEDIUM"
+      {% if request.args.get('difficulty') == 'MEDIUM' %}selected{% endif %}>
+      Medium
+      </option>
+
+      <option value="HARD"
+      {% if request.args.get('difficulty') == 'HARD' %}selected{% endif %}>
+      Hard
+      </option>
+    </select>
+
+    <select class="search-field" name="category">
+      <option value="">All Categories</option>
+      <option value="BREAKFAST">Breakfast</option>
+      <option value="BRUNCH">Brunch</option>
+      <option value="LUNCH">Lunch</option>
+      <option value="DINNER">Dinner</option>
+      <option value="SNACK">Snack</option>
+      <option value="DRINK">Drink</option>
+
+      <option value="DESSERT"
+      {% if request.args.get('category') == 'DESSERT' %}selected{% endif %}>
+      Dessert
+      </option>
+    </select>
+
+    <select class="search-field" name="sort">
+      <option value="">Sort By</option>
+
+      <option value="alphabetical"
+      {% if request.args.get('sort') == 'alphabetical' %}selected{% endif %}>
+      Alphabetical
+      </option>
+
+      <option value="newest"
+      {% if request.args.get('sort') == 'newest' %}selected{% endif %}>
+      Newest
+      </option>
+    </select>
+
+  </div>
+</form>
+</div>
+
+  {% if results %}
 
   <div class="row g-4 search-results-grid">
     {% for recipe in results %}


### PR DESCRIPTION
This PR refactors recipe browsing and search into a unified `/recipes` experience.

Changes included:

* converted '/recipes' into the main all-recipes + search-results page
* removed duplicated '/search' route logic
* homepage search now routes directly into '/recipes?q=...'
* added dynamic headings for browse/search modes
* improved recipe browsing layout with dedicated page-specific styling
* added isolated 'search_results.css' overrides to avoid affecting shared homepage card layouts

This creates a cleaner architecture for future filtering and AJAX enhancements while keeping reusable recipe card components intact.
