### PR TITLE
fix: add favicon links to resolve 404 icon error

### DIFF
--- a/app/static/js/navbar_script.js
+++ b/app/static/js/navbar_script.js
@@ -16,3 +16,8 @@ if (navbar) {
         lastScrollY = currentScrollY;
     });
 }
+
+// Wait for fonts to load before showing Material Icons
+document.fonts.ready.then(() => {
+    document.documentElement.classList.add('fonts-loaded');
+});

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -6,6 +6,8 @@ to appear on EVERY page should be added here. #}
 <html>
   <head>
     <title>CozyCravings</title>
+    <link rel="icon" type="image/png" href="{{ url_for('static', filename='images/logo.png') }}">
+    <link rel="apple-touch-icon" href="{{ url_for('static', filename='images/logo.png') }}">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
     <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">


### PR DESCRIPTION
- Added rel="icon" and rel="apple-touch-icon" link tags to the top of base.html <head> to prevent the browser from auto-requesting missing favicon files. 
- Also added document.fonts.ready handler in navbar_script.js and Material Icons visibility fix in style.css to prevent icons rendering as raw text before the Google Fonts CDN loads.